### PR TITLE
Change how to handle envs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+BASE_URL="http://localhost:3000"

--- a/.gitignore
+++ b/.gitignore
@@ -26,8 +26,9 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
-.env*.local
-.env
+.env.development
+.env.test
+.env.production
 
 
 # vercel

--- a/src/lib/api/instance.ts
+++ b/src/lib/api/instance.ts
@@ -1,10 +1,7 @@
 import axios from "axios";
 
 export const axiosInstance = axios.create({
-  baseURL:
-    process.env.NODE_ENV === "development"
-      ? "http://localhost:2002"
-      : "https://api.crclevents.com",
+  baseURL: process.env.BASE_URL,
 });
 
 const getLocalStorageItem = (key: string): string | null => {


### PR DESCRIPTION
This PR contains a control on what the base url for the api is based on NODE_ENV, also an example of env is pushed.

In dev stage the run command will be:
```bash
NODE_ENV=test + the run command
```

and 
```bash
NODE_ENV=production + the run command
```